### PR TITLE
Autoload using absolute paths

### DIFF
--- a/PutIO/Autoloader.php
+++ b/PutIO/Autoloader.php
@@ -25,6 +25,9 @@ spl_autoload_register(function($className)
         }
            
         $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
+        
+        $fileName = dirname(__FILE__) . "/../" . $fileName;
+        
         require $fileName;
     }
 });


### PR DESCRIPTION
We had an issue (derpware/derptracker#15) when using this library, which required us to change the path in the Autoloader.php. Upon closer examination, I figured this could be addressed by using absolute paths for loading classes, instead of relative paths.

This solves our issue, and should also not do any harm for other projects using this library.
