### PR TITLE
Fix the mp4 capitalization in mp4 file version download link

### DIFF
--- a/PutIO/Engines/PutIO/FilesEngine.php
+++ b/PutIO/Engines/PutIO/FilesEngine.php
@@ -185,7 +185,7 @@ class FilesEngine extends PutIOHelper
             $saveAs = $info['name'];
         }
         
-        return $this->downloadFile('files/' . $fileID . '/' . ($isMP4 ? 'MP4/' : '') . 'download', $saveAs);
+        return $this->downloadFile('files/' . $fileID . '/' . ($isMP4 ? 'mp4/' : '') . 'download', $saveAs);
     }
     
     


### PR DESCRIPTION
Put.io must have changed the capitalization of the method to download MP4 files.
